### PR TITLE
chrore(deps): remove missused renovate `monorepo` configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:js-lib", "config:monorepo"],
+  "extends": ["config:js-lib"],
   "semanticCommits": true,
   "rebaseStalePrs": true,
   "automerge": true,


### PR DESCRIPTION
Following the insight of @rarkins on one of my previous commit: https://github.com/ubirak/ubirak-js/commit/f300c3a44edd41ac894a65ab91a969f87e4673d1#r26039586